### PR TITLE
ベット額の最小値と最大値の設定を追加

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -12,6 +12,7 @@ input[type="number"] {
   margin: 10px;
   border-radius: 10px;
   font-size: 120%;
+  width: 250px;
 }
 
 input[type="number"]:focus {

--- a/src/main/resources/templates/lobby.html
+++ b/src/main/resources/templates/lobby.html
@@ -43,7 +43,7 @@
     所持コイン数：[[${coin}]] 枚
   </div>
   <form th:action="@{/blackjack/gamestart}" method="post">
-    <input type="number" name="bet" placeholder="ベット額を入力" required>
+    <input type="number" name="bet" min="1" th:max="${coin}" placeholder="ベット額を入力" required>
     <br>
     <a href="/blackjack/returnhome">退室</a>
     <input type="submit" value="ゲームスタート">


### PR DESCRIPTION
ロビー画面でベット額を入力する際，入力値が1以上所持金以下の場合のみ画面遷移するように変更．