### PR TITLE
画面サイズを細くした際にplayerlistが勝手に改行するように変更

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -58,6 +58,7 @@ ul li {
 #players_list {
   display: flex;
   justify-content: center;
+  flex-wrap: wrap;
 }
 
 #players_list p {


### PR DESCRIPTION
画面サイズを細くするとmember要素の幅も細くなるのでカードの表示が崩れていました
member要素の幅を変えず次の行に変わることでその表示崩れを直しました
![image](https://user-images.githubusercontent.com/75178714/212488431-69dbcc09-44ca-4958-bf21-3c40e984ccf4.png)
