### PR TITLE
ボタンのdisplay属性をinline-blockに変更

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -27,6 +27,7 @@ input[type="submit"] {
 a,
 button,
 input[type="submit"] {
+  display: inline-block;
   margin: 10px;
   padding: 5px 15px;
   border: none;


### PR DESCRIPTION
画面サイズを細くした際にボタンが改行され上下が重なる問題を修正
![image](https://user-images.githubusercontent.com/75178714/212488579-3f09db4b-488e-4f10-92cb-a6e014151936.png)
